### PR TITLE
Fix instant multiplayer desync with Jeweled Gauntlet rune / 修复镶宝铁拳符文联机即时断线

### DIFF
--- a/海克斯符文/本体/src/Mayhem/HextechCombatProcTracker.cs
+++ b/海克斯符文/本体/src/Mayhem/HextechCombatProcTracker.cs
@@ -58,6 +58,11 @@ internal static class HextechCombatProcTracker
 		return true;
 	}
 
+	public static int GetPlayerRuneProcsInCombat(HextechMayhemCombatTrackingState tracking, Player player, string procKey)
+	{
+		return tracking.PlayerRuneProcsThisCombat.GetValueOrDefault(GetPlayerRuneProcKey(player, procKey), 0);
+	}
+
 	public static int ConsumePlayerRuneProcInCombat(HextechMayhemCombatTrackingState tracking, Player player, string procKey)
 	{
 		string key = GetPlayerRuneProcKey(player, procKey);

--- a/海克斯符文/本体/src/Mayhem/HextechMayhem.Effects.cs
+++ b/海克斯符文/本体/src/Mayhem/HextechMayhem.Effects.cs
@@ -22,6 +22,11 @@ internal sealed partial class HextechMayhemModifier
 		return HextechCombatProcTracker.TryConsumePlayerRuneProcThisTurn(_combatTracking, player, procKey, maxPerTurn);
 	}
 
+	internal int GetPlayerRuneProcsInCombat(Player player, string procKey)
+	{
+		return HextechCombatProcTracker.GetPlayerRuneProcsInCombat(_combatTracking, player, procKey);
+	}
+
 	internal int ConsumePlayerRuneProcInCombat(Player player, string procKey)
 	{
 		return HextechCombatProcTracker.ConsumePlayerRuneProcInCombat(_combatTracking, player, procKey);

--- a/海克斯符文/本体/src/Relics/Base/HextechRelicBase.TurnProc.cs
+++ b/海克斯符文/本体/src/Relics/Base/HextechRelicBase.TurnProc.cs
@@ -121,6 +121,21 @@ public abstract partial class HextechRelicBase
 		return true;
 	}
 
+	// 只读、不消费。ModifyCardPlayCount 等引擎可能针对同一次出牌重复调用的钩子只应在这里取序号；
+	// 真正的消费(推进共享计数)必须放在 AfterModifyingCardPlayCount 等每次出牌只触发一次的钩子里,
+	// 调用下面的 ConsumeCombatProcOrdinal,否则联机端序号推进次数不一致会导致稳定随机结果分叉。
+	protected int PeekCombatProcOrdinal(string procKey, int localCount)
+	{
+		if (ShouldUseNetworkCombatHistory()
+			&& Owner != null
+			&& Owner.RunState.Modifiers.OfType<HextechMayhemModifier>().LastOrDefault() is HextechMayhemModifier modifier)
+		{
+			return modifier.GetPlayerRuneProcsInCombat(Owner, procKey);
+		}
+
+		return localCount;
+	}
+
 	protected int ConsumeCombatProcOrdinal(string procKey, ref int localCount)
 	{
 		if (ShouldUseNetworkCombatHistory()

--- a/海克斯符文/本体/src/Runes/JeweledGauntletRune.cs
+++ b/海克斯符文/本体/src/Runes/JeweledGauntletRune.cs
@@ -26,7 +26,7 @@ public sealed class JeweledGauntletRune : HextechRelicBase
 			return playCount;
 		}
 
-		int ordinal = ConsumeCombatProcOrdinal(nameof(JeweledGauntletRune), ref _replayRollsThisCombat);
+		int ordinal = PeekCombatProcOrdinal(nameof(JeweledGauntletRune), _replayRollsThisCombat);
 		bool shouldReplay = HextechStableRandom.PercentChance(
 			(RunState)Owner.RunState,
 			33,
@@ -43,9 +43,14 @@ public sealed class JeweledGauntletRune : HextechRelicBase
 
 	public override Task AfterModifyingCardPlayCount(CardModel card)
 	{
-		if (Owner != null && card.Owner == Owner && _pendingReplayRollCard == card && _pendingReplayRollResult)
+		if (Owner != null && card.Owner == Owner && _pendingReplayRollCard == card)
 		{
-			Flash();
+			// 只在这个每次出牌保证只触发一次的钩子里消费序号,避免 ModifyCardPlayCount 被引擎重复调用时序号多推进。
+			ConsumeCombatProcOrdinal(nameof(JeweledGauntletRune), ref _replayRollsThisCombat);
+			if (_pendingReplayRollResult)
+			{
+				Flash();
+			}
 		}
 
 		if (_pendingReplayRollCard == card)

--- a/海克斯符文/本体/src/Runes/JeweledGauntletRune.cs
+++ b/海克斯符文/本体/src/Runes/JeweledGauntletRune.cs
@@ -3,8 +3,12 @@ namespace HextechRunes;
 public sealed class JeweledGauntletRune : HextechRelicBase
 {
 	private int _replayRollsThisCombat;
-	private CardModel? _pendingReplayRollCard;
-	private bool _pendingReplayRollResult;
+
+	// 按 card 实例分槽存放待定的重打判定结果,而不是单一共享槽位:引擎/UI 可能在同一张牌的
+	// ModifyCardPlayCount 与 AfterModifyingCardPlayCount 之间,针对手牌里其它牌再次调用
+	// ModifyCardPlayCount(例如出牌次数预测类 UI 轮询),若用单一槽位会被那次调用覆盖,导致
+	// AfterModifyingCardPlayCount 认错牌、漏消费序号、漏播特效。
+	private readonly Dictionary<CardModel, bool> _pendingReplayRolls = new();
 
 	public override Task BeforeCombatStart()
 	{
@@ -22,7 +26,7 @@ public sealed class JeweledGauntletRune : HextechRelicBase
 	{
 		if (Owner == null || card.Owner != Owner)
 		{
-			ClearPendingReplayRoll();
+			_pendingReplayRolls.Remove(card);
 			return playCount;
 		}
 
@@ -36,26 +40,24 @@ public sealed class JeweledGauntletRune : HextechRelicBase
 			ordinal.ToString(),
 			TargetKey(target),
 			HextechStableRandom.CardKey(card));
-		_pendingReplayRollCard = card;
-		_pendingReplayRollResult = shouldReplay;
+		_pendingReplayRolls[card] = shouldReplay;
 		return shouldReplay ? playCount + 1 : playCount;
 	}
 
 	public override Task AfterModifyingCardPlayCount(CardModel card)
 	{
-		if (Owner != null && card.Owner == Owner && _pendingReplayRollCard == card)
+		if (Owner != null && card.Owner == Owner && _pendingReplayRolls.Remove(card, out bool shouldReplay))
 		{
 			// 只在这个每次出牌保证只触发一次的钩子里消费序号,避免 ModifyCardPlayCount 被引擎重复调用时序号多推进。
 			ConsumeCombatProcOrdinal(nameof(JeweledGauntletRune), ref _replayRollsThisCombat);
-			if (_pendingReplayRollResult)
+			if (shouldReplay)
 			{
 				Flash();
 			}
 		}
-
-		if (_pendingReplayRollCard == card)
+		else
 		{
-			ClearPendingReplayRoll();
+			_pendingReplayRolls.Remove(card);
 		}
 
 		return Task.CompletedTask;
@@ -69,12 +71,6 @@ public sealed class JeweledGauntletRune : HextechRelicBase
 	private void ResetReplayRollState()
 	{
 		_replayRollsThisCombat = 0;
-		ClearPendingReplayRoll();
-	}
-
-	private void ClearPendingReplayRoll()
-	{
-		_pendingReplayRollCard = null;
-		_pendingReplayRollResult = false;
+		_pendingReplayRolls.Clear();
 	}
 }

--- a/海克斯符文/本体/tests/HextechRunes.Tests/Program.cs
+++ b/海克斯符文/本体/tests/HextechRunes.Tests/Program.cs
@@ -3,6 +3,7 @@ using System.Runtime.CompilerServices;
 using HextechRunes;
 using MegaCrit.Sts2.Core.Commands.Builders;
 using MegaCrit.Sts2.Core.Entities.Creatures;
+using MegaCrit.Sts2.Core.Entities.Players;
 using MegaCrit.Sts2.Core.Entities.Relics;
 using MegaCrit.Sts2.Core.GameActions;
 using MegaCrit.Sts2.Core.Models;
@@ -71,6 +72,7 @@ internal static class Program
 				new(nameof(NetworkChoiceTimeoutUsesNominalWallClockSeconds), NetworkChoiceTimeoutUsesNominalWallClockSeconds),
 				new(nameof(CombatTrackingPerTurnProcLimitsResetOncePerRound), CombatTrackingPerTurnProcLimitsResetOncePerRound),
 				new(nameof(CombatTrackingGlobalProcOrdinalsSerializeAndReset), CombatTrackingGlobalProcOrdinalsSerializeAndReset),
+				new(nameof(CombatTrackingPlayerRuneProcOrdinalPeekDoesNotConsume), CombatTrackingPlayerRuneProcOrdinalPeekDoesNotConsume),
 			new(nameof(CombatTrackingSerializationIsCultureInvariant), CombatTrackingSerializationIsCultureInvariant),
 			new(nameof(SavedPropertyManifestMatchesCheckedInList), SavedPropertyManifestMatchesCheckedInList),
 			new(nameof(ConfigMigrationForceResetsBelowV15), ConfigMigrationForceResetsBelowV15),
@@ -446,6 +448,28 @@ internal static class Program
 
 		restored.Reset();
 		Equal(0, restored.GlobalProcsThisCombat.Count, "global proc count should clear on combat tracking reset");
+	}
+
+	// 回归测试:镶宝铁拳符文曾经在 ModifyCardPlayCount(引擎可能对同一次出牌重复求值,例如 UI 预测出牌次数的轮询)
+	// 里直接调用会推进计数的 ConsumePlayerRuneProcInCombat,导致联机端序号推进次数不一致、稳定随机结果分叉出即时
+	// 断线。修复后 ModifyCardPlayCount 只应 peek(GetPlayerRuneProcsInCombat),真正消费必须挪到每次出牌只触发一次
+	// 的 AfterModifyingCardPlayCount 里调用 ConsumePlayerRuneProcInCombat。这里验证該契约本身。
+	private static void CombatTrackingPlayerRuneProcOrdinalPeekDoesNotConsume()
+	{
+		HextechMayhemCombatTrackingState tracking = new();
+		Player player = CreateOrdinalTestPlayer(7);
+		const string procKey = nameof(JeweledGauntletRune);
+
+		Equal(0, HextechCombatProcTracker.GetPlayerRuneProcsInCombat(tracking, player, procKey), "peek before any play should read zero");
+		Equal(0, HextechCombatProcTracker.GetPlayerRuneProcsInCombat(tracking, player, procKey), "repeated peeks must not mutate the ordinal");
+		Equal(0, HextechCombatProcTracker.GetPlayerRuneProcsInCombat(tracking, player, procKey), "a speculative ModifyCardPlayCount re-evaluation must be side-effect free");
+
+		Equal(0, HextechCombatProcTracker.ConsumePlayerRuneProcInCombat(tracking, player, procKey), "first real play should consume ordinal 0");
+		Equal(1, HextechCombatProcTracker.GetPlayerRuneProcsInCombat(tracking, player, procKey), "peek after one real play should reflect the committed ordinal");
+		Equal(1, HextechCombatProcTracker.GetPlayerRuneProcsInCombat(tracking, player, procKey), "peeking again before the next real play must not advance the ordinal");
+
+		Equal(1, HextechCombatProcTracker.ConsumePlayerRuneProcInCombat(tracking, player, procKey), "second real play should consume ordinal 1");
+		Equal(2, HextechCombatProcTracker.GetPlayerRuneProcsInCombat(tracking, player, procKey), "ordinal should advance exactly once per real play, never per peek");
 	}
 
 	private static void CombatTrackingSerializationIsCultureInvariant()
@@ -1677,6 +1701,18 @@ internal static class Program
 	private static ModelId TestMonsterHexIconId(MonsterHexKind kind)
 	{
 		return new ModelId("HEXTECH_TEST", $"MONSTER_HEX_{(int)kind}");
+	}
+
+	// Player 的构造函数会触达 SaveManager/PlatformUtil 等只在真实 Godot 运行时下才可用的原生绑定,
+	// 在纯 CLI 测试进程里直接 new 会段错误。这里只需要一个能承载稳定 NetId 的壳子来复用
+	// GetPlayerRuneProcKey 的联机计费键,故跳过构造函数,直接反射写入 NetId 的自动属性支持字段。
+	private static Player CreateOrdinalTestPlayer(ulong netId)
+	{
+		Player player = (Player)RuntimeHelpers.GetUninitializedObject(typeof(Player));
+		typeof(Player)
+			.GetField("<NetId>k__BackingField", BindingFlags.NonPublic | BindingFlags.Instance)!
+			.SetValue(player, netId);
+		return player;
 	}
 
 	private static void Expect(bool condition, string message)


### PR DESCRIPTION
## Summary / 概述

**English:** In ARAM Mayhem multiplayer, equipping the Jeweled Gauntlet rune (33% chance to replay a card) caused an almost-instant desync as soon as a card was played.

**中文:** 在海克斯大乱斗联机对局中，装备镶宝铁拳符文（33% 概率重打出牌）后，几乎在第一次出牌时就会立刻触发断线。

## Root cause / 根因

**English:** `JeweledGauntletRune.ModifyCardPlayCount` called the network-shared, *mutating* proc-ordinal consumer (`ConsumeCombatProcOrdinal` → `HextechMayhemModifier.ConsumePlayerRuneProcInCombat`) directly inside `ModifyCardPlayCount`. That hook is not guaranteed to fire only once per real card play — every other rune in this codebase that touches `ModifyCardPlayCount` (`TriPrismRune`, `FanTheHammerRune`, `TwiceThriceRune`, `LightEmUpRune`, `UltimateRefreshRune`, etc.) already treats it as a read-only/idempotent hook, deferring any state mutation to `AfterModifyingCardPlayCount`, which the engine only calls once per actually-resolved play. Jeweled Gauntlet was the one exception.

If `ModifyCardPlayCount` is re-evaluated for the same logical play (e.g. by a card-cost/replay-count preview refresh, or by the engine itself), the old code would advance the shared ordinal an extra time on whichever client triggered the re-evaluation. From that point on, every subsequent 33% replay roll used a different ordinal salt on different clients — meaning a different actual replay outcome per client, hence a hard state divergence almost immediately.

**中文:** `JeweledGauntletRune.ModifyCardPlayCount` 之前直接在这个钩子里调用了会 **推进** 联机共享计数的 `ConsumeCombatProcOrdinal`（内部即 `HextechMayhemModifier.ConsumePlayerRuneProcInCombat`）。但引擎并不保证 `ModifyCardPlayCount` 对同一次出牌只调用一次 —— 本仓库里所有其它涉及 `ModifyCardPlayCount` 的符文（`TriPrismRune`、`FanTheHammerRune`、`TwiceThriceRune`、`LightEmUpRune`、`UltimateRefreshRune` 等）都已经把它当作只读、幂等的钩子处理，把真正的状态消费延后到每次出牌只保证触发一次的 `AfterModifyingCardPlayCount` 里。镶宝铁拳符文是唯一的例外。

一旦 `ModifyCardPlayCount` 针对同一次出牌被重复求值（例如出牌次数/费用预览刷新，或引擎自身的重复求值），旧代码就会在触发重复求值的那一端多推进一次共享序号。此后该符文每一次 33% 重打判定在各端使用的序号盐值都会不一致，也就是各端的重打结果直接不同，几乎立刻造成实打实的状态分叉（断线）。

## Fix / 修复方案

**English:** Split "peek" from "consume", mirroring the pattern already used by the other runes:
- Added `HextechCombatProcTracker.GetPlayerRuneProcsInCombat` (read-only) alongside the existing mutating `ConsumePlayerRuneProcInCombat`.
- Exposed it through `HextechMayhemModifier`.
- Added `HextechRelicBase.PeekCombatProcOrdinal`, the non-mutating counterpart to `ConsumeCombatProcOrdinal`.
- `JeweledGauntletRune.ModifyCardPlayCount` now only *peeks* the ordinal to decide the roll; `AfterModifyingCardPlayCount` (guaranteed once per resolved play) now performs the actual `ConsumeCombatProcOrdinal` call.

**中文:** 参照其它符文已经在用的模式，把"读取"和"消费"拆开：
- 新增只读的 `HextechCombatProcTracker.GetPlayerRuneProcsInCombat`，与既有的会推进计数的 `ConsumePlayerRuneProcInCombat` 并列。
- 通过 `HextechMayhemModifier` 暴露该只读方法。
- 新增 `HextechRelicBase.PeekCombatProcOrdinal`，作为 `ConsumeCombatProcOrdinal` 的非消费版本。
- `JeweledGauntletRune.ModifyCardPlayCount` 现在只 peek 序号来决定这次判定结果；真正的 `ConsumeCombatProcOrdinal` 调用挪到了每次出牌只保证触发一次的 `AfterModifyingCardPlayCount` 里。

## Follow-up fix / 后续修复

**English:** In-game testing (after the fix above) surfaced a second, related bug: the peek/consume hand-off used a single pair of scalar fields (`_pendingReplayRollCard`/`_pendingReplayRollResult`) to carry the roll result from `ModifyCardPlayCount` to `AfterModifyingCardPlayCount`. That's only safe if nothing else calls `ModifyCardPlayCount` for a *different* card in between — but other systems (e.g. a "predicted play count" UI) legitimately poll `ModifyCardPlayCount` for other cards still in hand. When that happened between the real evaluation of card A and its own `AfterModifyingCardPlayCount`, the shared slot got overwritten with card B's result, so `AfterModifyingCardPlayCount(A)` silently skipped consuming the ordinal and skipped the flash VFX. The ordinal then permanently trailed by one relative to what later predictions/rolls expected, causing visible mismatches between the predicted replay count and the actual outcome (deterministic on both clients — no longer a desync, just wrong). Fixed by tracking the pending roll per-card in a small dictionary instead of a single shared slot, so a poll for one card can never clobber another's pending result.

**中文:** 应用上面的修复后进行联机实测，发现了第二个相关问题：peek/consume 之间用单一的一对标量字段（`_pendingReplayRollCard`/`_pendingReplayRollResult`）在两个钩子间传递判定结果，这只有在两次调用之间没有其它牌调用过 `ModifyCardPlayCount` 时才安全——但像"出牌次数预测"类 UI 这样的系统会合理地针对手牌里其它牌轮询 `ModifyCardPlayCount`。若这发生在牌 A 的真实求值与它自己的 `AfterModifyingCardPlayCount` 之间，共享槽位就会被牌 B 的结果覆盖，导致 `AfterModifyingCardPlayCount(A)` 静默跳过序号消费与特效播放。此后序号相对于后续判定预期的值永久落后一位，表现为预测的重打次数与实际结果不符（两端结果一致，不再是断线，只是结果错）。修复方式：改为用一个小字典按 card 实例分别存放待定判定结果，而不是单一共享槽位，这样针对某张牌的轮询就不会覆盖另一张牌的待定结果。

## Testing / 测试

- `dotnet build` for both `src/HextechRunes.csproj` and `tests/HextechRunes.Tests.csproj` against game v0.108.0 — clean, no new warnings.
- Full existing test suite: 79/79 passing, no regressions.
- Added a regression test, `CombatTrackingPlayerRuneProcOrdinalPeekDoesNotConsume`, verifying the contract the first fix depends on: peeking the ordinal any number of times never mutates it, while consuming advances it by exactly one per call. Verified the test actually catches the old bug pattern by temporarily making peek call through to consume and confirming the test fails, then reverted.
- The follow-up fix (per-card tracking) was verified via live multiplayer playtesting rather than an automated test — `JeweledGauntletRune` depends on `Player`/`RunState`/combat runtime objects that cannot be constructed outside the running Godot engine (confirmed empirically: `Player`'s real constructor touches native Godot bindings and `SaveManager.Instance` and segfaults when invoked standalone), the same limitation noted for the first fix's test coverage.
- 已针对 v0.108.0 游戏版本分别构建 `src/HextechRunes.csproj` 与 `tests/HextechRunes.Tests.csproj`，构建通过，无新增警告。
- 完整回归测试 79/79 全部通过，未引入新的失败。
- 新增回归测试 `CombatTrackingPlayerRuneProcOrdinalPeekDoesNotConsume`，验证第一次修复依赖的核心契约：无论 peek 多少次都不会推进序号，只有消费操作才会且每次仅推进 1。并通过临时让 peek 内部走消费逻辑来复现旧 bug，确认该测试确实会失败，验证测试有效后已还原。
- 后续修复（按牌分槽）通过联机实测验证，而非自动化测试——`JeweledGauntletRune` 依赖无法在 Godot 引擎外构造的 `Player`/`RunState`/战斗运行时对象（已实测确认：`Player` 的真实构造函数会触达原生 Godot 绑定与 `SaveManager.Instance`，脱离引擎单独调用会段错误），与第一次修复的测试覆盖存在相同限制。